### PR TITLE
change port from string to int

### DIFF
--- a/stable/factorio/templates/factorio-svc.yaml
+++ b/stable/factorio/templates/factorio-svc.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.factorioServer.serviceType }}
   ports:
   - name: factorio
-    port: {{ .Values.factorioServer.port | quote }}
+    port: {{ .Values.factorioServer.port | int }}
     targetPort: factorio
     protocol: UDP
   selector:


### PR DESCRIPTION
It seems, ports in services must be integers.

Should fix https://github.com/kubernetes/charts/pull/547.